### PR TITLE
Update the parallel flag to the correct parameter "-P"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.expedia</groupId>
   <artifactId>scalatest-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0</version>
+  <version>1.0.1</version>
   <name>ScalaTest Maven Plugin</name>
   <description>Integrates ScalaTest into Maven</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>7</version>
   </parent>
 
-  <groupId>org.scalatest</groupId>
+  <groupId>com.expedia</groupId>
   <artifactId>scalatest-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
   <version>1.0</version>
@@ -16,8 +16,8 @@
   <description>Integrates ScalaTest into Maven</description>
 
   <properties>
-    <scala.version>2.10.0</scala.version>
-    <deploy.scala.version>2.10</deploy.scala.version>
+    <scala.version>2.12.1</scala.version>
+    <deploy.scala.version>2.12</deploy.scala.version>
     <scalatest.version>2.0</scalatest.version>
     <maven.scala.plugin.version>2.14.1</maven.scala.plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <groupId>com.expedia</groupId>
   <artifactId>scalatest-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-  <version>1.0.1</version>
+  <version>1.0.1-SNAPSHOT</version>
   <name>ScalaTest Maven Plugin</name>
   <description>Integrates ScalaTest into Maven</description>
 

--- a/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
+++ b/src/main/java/org/scalatest/tools/maven/AbstractScalaTestMojo.java
@@ -434,7 +434,7 @@ abstract class AbstractScalaTestMojo extends AbstractMojo {
     }
 
     private List<String> parallel() {
-        return parallel ? singletonList("-c") : Collections.<String>emptyList();
+        return parallel ? singletonList("-P") : Collections.<String>emptyList();
     }
 
     //

--- a/src/test/scala/org/scalatest/tools/maven/PluginTest.scala
+++ b/src/test/scala/org/scalatest/tools/maven/PluginTest.scala
@@ -103,8 +103,8 @@ class PluginTest extends JUnit3Suite with ShouldMatchers with PluginMatchers wit
   }
 
   def testConcurrent {
-    configure(_.parallel = true) should contain("-c")
-    configure(_.parallel = false) should not contain ("-c")
+    configure(_.parallel = true) should contain("-P")
+    configure(_.parallel = false) should not contain ("-P")
   }
 
   def testSuites {


### PR DESCRIPTION
We are updating to the correct parallel flag, as the scalatest plugin hasn't been updated for a while and we require to work for scala 2.12.  Scala 2.12 now does not give deprecation notice anymore, but an IllegalArgumentException.  This update is to change the "-c" flag to "-P" flag.

Also have updated to the latest scala version and changed the groupId.